### PR TITLE
Notifications group renamed to 'OpenShift Connector'

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/Constants.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/Constants.java
@@ -16,7 +16,7 @@ public class Constants {
 
     public static final String MIGRATION_HELP_PAGE_URL = "https://github.com/redhat-developer/intellij-openshift-connector/wiki/Migration-to-v0.1.0";
 
-    public static final String GROUP_DISPLAY_ID = "OpenShift";
+    public static final String GROUP_DISPLAY_ID = "OpenShift Connector";
 
     public static final String CLUSTER_MIGRATION_TITLE = "Cluster migration";
     public static final String CLUSTER_MIGRATION_MESSAGE = "Some of the resources in cluster must be updated to work with latest release of OpenShift Connector plugin";


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

## What is the purpose of this change? What does it change?

Renamed the notification group for this plugin to 'OpenShift Connector'

