### PR TITLE
allow running gradle build with jdk11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     compile 'me.snowdrop:servicecatalog-client:1.0.1'
     compile 'org.apache.commons:commons-compress:1.19'
     compile 'org.apache.commons:commons-exec:1.3'
+    compile 'org.apache.commons:commons-lang3:3.9'
     testCompile 'org.mockito:mockito-core:2.23.4'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion = IC-2018.1
+ideaVersion = IC-2018.2
 projectVersion=0.1.1-SNAPSHOT
 jetBrainsToken=invalid
 jetBrainsChannel=stable


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Changes required to build using jdk11

## Was the change discussed in an issue?
fixes #97

## How to test changes?
run gradle build either in intellij or command-line