### PR TITLE
added colons to labels for "Cluster URL", "Token" (#110)

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/cluster/LoginDialog.form
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/cluster/LoginDialog.form
@@ -24,7 +24,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Cluster URL"/>
+              <text value="Cluster URL:"/>
             </properties>
           </component>
           <component id="f6bd7" class="javax.swing.JLabel">
@@ -72,7 +72,7 @@
               <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Token"/>
+              <text value="Token:"/>
             </properties>
           </component>
           <component id="aaee2" class="javax.swing.JTextField" binding="tokenField">


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Added ":" to the "Cluster URL" and "Token" in "Cluster login"

## Was the change discussed in an issue?
fixes #110 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Open "Cluster login" dialog. Look at "Cluster URL" and "Token"