### PR TITLE
Added colongs to labels in CreateComponentDialogStep (#114)

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/component/CreateComponentDialogStep.form
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/component/CreateComponentDialogStep.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="502" height="400"/>
+      <xy x="20" y="20" width="529" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -21,7 +21,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Name"/>
+              <text value="Name:"/>
             </properties>
           </component>
           <component id="8a9f2" class="javax.swing.JTextField" binding="nameTextField">
@@ -37,7 +37,7 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Source type"/>
+              <text value="Source type:"/>
             </properties>
           </component>
           <component id="52143" class="javax.swing.JComboBox" binding="sourceTypeComboBox">
@@ -51,7 +51,7 @@
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Context"/>
+              <text value="Context:"/>
             </properties>
           </component>
           <component id="eae1d" class="javax.swing.JTextField" binding="contextTextField">
@@ -67,7 +67,7 @@
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Component type"/>
+              <text value="Component type:"/>
             </properties>
           </component>
           <component id="538de" class="javax.swing.JComboBox" binding="componentTypeComboBox">
@@ -81,7 +81,7 @@
               <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Component version"/>
+              <text value="Component version:"/>
             </properties>
           </component>
           <component id="2e30" class="javax.swing.JComboBox" binding="componentVersionComboBox">
@@ -95,7 +95,7 @@
               <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Application"/>
+              <text value="Application:"/>
             </properties>
           </component>
           <component id="2ac00" class="javax.swing.JTextField" binding="applicationTextField">
@@ -111,7 +111,7 @@
               <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Push after create"/>
+              <text value="Push after create:"/>
             </properties>
           </component>
           <component id="679c3" class="javax.swing.JCheckBox" binding="pushAfterCreateCheckBox">


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Adds missing colons to labels in the the create form that's presented when creating a component.

## Was the change discussed in an issue?
fixes #114
<!-- Please do Link issues here. -->
