### PR TITLE
added ":" to labels, top-aligned forms for create comp wiz

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/component/CreateComponentDialogBinaryStep.form
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/component/CreateComponentDialogBinaryStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jboss.tools.intellij.openshift.ui.component.CreateComponentDialogBinaryStep">
-  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -13,7 +13,7 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Binary file"/>
+          <text value="Binary file:"/>
         </properties>
       </component>
       <component id="bfcd7" class="javax.swing.JTextField" binding="binaryFileTextField">
@@ -26,12 +26,17 @@
       </component>
       <component id="19172" class="javax.swing.JButton" binding="browseButton">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="2" row-span="2" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Browse"/>
         </properties>
       </component>
+      <vspacer id="93849">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/component/CreateComponentDialogGitStep.form
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/component/CreateComponentDialogGitStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jboss.tools.intellij.openshift.ui.component.CreateComponentDialogGitStep">
-  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -13,7 +13,7 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Repository url"/>
+          <text value="Repository url:"/>
         </properties>
       </component>
       <component id="f06ab" class="javax.swing.JTextField" binding="urlTextField">
@@ -29,7 +29,7 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Reference"/>
+          <text value="Reference:"/>
         </properties>
       </component>
       <component id="91a81" class="javax.swing.JTextField" binding="referenceTextField">
@@ -40,6 +40,11 @@
         </constraints>
         <properties/>
       </component>
+      <vspacer id="6f3d6">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
* top aligns step 2 in the "create component" wizard:
  * "binary" 
  * and "git" 
* adds ":" colons to labels

## How to test changes?
Steps:
1. ASSERT: have cluster with project
1. EXEC: pick "New Component" in ctx menu for the project
1. ASSERT: "Create Component" wizard shows up
1. EXEC: choose "Git" for "Source type"

Result:
![image](https://user-images.githubusercontent.com/25126/68242111-306abe00-0010-11ea-9eff-56e4aa662cd7.png)

Steps:
1. EXEC: choose "Binary" for "Source type"

Result:
![image](https://user-images.githubusercontent.com/25126/68242437-cacb0180-0010-11ea-9e45-b3cbfa62a15d.png)
In both forms ":" with the labels are missing and the rows should be top aligned, dropping the unused space that's in btw. the borders and btw. them

With this change, the forms look as follows:
![image](https://user-images.githubusercontent.com/25126/68242277-88a1c000-0010-11ea-8603-360ac55d7239.png)
![image](https://user-images.githubusercontent.com/25126/68242290-8e97a100-0010-11ea-8412-b74e06a0b99f.png)

