### PR TITLE
use high sensitivity watch service on MacOS (#127)

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/utils/ConfigWatcher.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/utils/ConfigWatcher.java
@@ -50,11 +50,9 @@ public class ConfigWatcher implements Runnable {
         });
     }
 
-    private void runOnConfigChange(Runnable runnable) {
+    private void runOnConfigChange(final Runnable runnable) {
         try (WatchService service = FileSystems.getDefault().newWatchService()) {
-            config.getParentFile().toPath().register(service,
-                    StandardWatchEventKinds.ENTRY_MODIFY,
-                    StandardWatchEventKinds.ENTRY_DELETE);
+            registerWatchService(service);
             WatchKey key;
             while ((key = service.take()) != null) {
                 key.pollEvents().stream()
@@ -69,6 +67,16 @@ public class ConfigWatcher implements Runnable {
             e.printStackTrace();
         }
 
+    }
+
+    @NotNull
+    private void registerWatchService(WatchService service) throws IOException {
+        HighSensitivityRegistrar modifier = new HighSensitivityRegistrar();
+        modifier.registerService(config.getParentFile().toPath(),
+                new WatchEvent.Kind[]{
+                        StandardWatchEventKinds.ENTRY_MODIFY,
+                        StandardWatchEventKinds.ENTRY_DELETE},
+                service);
     }
 
     @NotNull

--- a/src/main/java/org/jboss/tools/intellij/openshift/utils/HighSensitivityRegistrar.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/utils/HighSensitivityRegistrar.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.intellij.openshift.utils;
+
+import com.intellij.openapi.util.SystemInfo;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Modifier;
+import java.nio.file.WatchService;
+
+/**
+ * A class that allows testing and grabbing SensitivityWatchEventModifier#HIGH
+ * reflectively. This allows the code to run in jdks where it does not exists
+ * (ex. IBM, etc.). SensitivityWatchEventModifier#HIGH is required for the
+ * {@link WatchService} to work ~reliably on MacOS where no native hooks but
+ * polling is used.
+ * 
+ * @see "https://bugs.openjdk.java.net/browse/JDK-7133447"
+ * @see "https://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else"
+ * 
+ * @author Andre Dietisheim
+ */
+public class HighSensitivityRegistrar {
+
+	private static final String HIGH = "HIGH";
+	private static final String QUALIFIED_CLASSNAME = "com.sun.nio.file.SensitivityWatchEventModifier";
+
+	public boolean isRequired() {
+		return isMac();
+	}
+
+	/**
+	 * for testing purposes
+	 **/
+	protected boolean isMac() {
+		return SystemInfo.isMac;
+	}
+
+	public boolean exists() {
+		return get() != null;
+	}
+
+	/**
+	 * Returns the SensitivityWatchEventModifier#HIGH if it exists (on sun jvms or
+	 * openjdk), {@code null} otherwise.
+	 *
+	 * @return
+	 */
+	public Modifier get() {
+		try {
+			Class<Modifier> sensitivityClass = getSensitivityWatchEventModifierClass();
+			return getEnumConstant(HIGH, sensitivityClass.getEnumConstants());
+		} catch (ClassNotFoundException | SecurityException e) {
+			return null;
+		}
+	}
+
+	public void registerService(Path path, WatchEvent.Kind<Path>[] kinds, WatchService service) throws IOException {
+		if (isRequired()
+				&& exists()) {
+			path.register(service, kinds, get());
+		} else {
+			path.register(service, kinds);
+		}
+
+	}
+
+	/**
+	 * for testing purposes
+	 **/
+	protected Class<Modifier> getSensitivityWatchEventModifierClass() throws ClassNotFoundException {
+		return (Class<Modifier>) Class.forName(QUALIFIED_CLASSNAME);
+	}
+
+	private Modifier getEnumConstant(String name, Modifier[] modifiers) {
+		for (Modifier modifier : modifiers) {
+			if (name.equals(modifier.name())) {
+				return modifier;
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/org/jboss/tools/intellij/openshift/utils/HighSensitivityRegistrarTest.java
+++ b/src/test/java/org/jboss/tools/intellij/openshift/utils/HighSensitivityRegistrarTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.intellij.openshift.utils;
+
+import org.junit.Test;
+
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Modifier;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class HighSensitivityRegistrarTest {
+
+	private TestableHighSensitivityRegistrar modifier = spy(new TestableHighSensitivityRegistrar());
+
+	@Test
+	public void isRequiredOnMacOS() {
+		// given
+		doReturn(true).when(modifier).isMac();
+		// when
+		boolean required = modifier.isRequired();
+		// then
+		assertThat(required).isTrue();
+	}
+
+	@Test
+	public void isNotRequiredOnNonMac() {
+		// given
+		doReturn(false).when(modifier).isMac();
+		// when
+		boolean required = modifier.isRequired();
+		// then
+		assertThat(required).isFalse();
+	}
+
+	@Test
+	public void getModifierIfAvailable() throws ClassNotFoundException {
+		// given
+		doReturn(SensitivityModifier.class).when(modifier).getSensitivityWatchEventModifierClass();
+		// when
+		Modifier highSensitivity = modifier.get();
+		// then
+		assertThat(highSensitivity).isNotNull();
+	}
+
+	@Test
+	public void existsIfIsAvailable() throws ClassNotFoundException {
+		// given
+		doReturn(SensitivityModifier.class).when(modifier).getSensitivityWatchEventModifierClass();
+		// when
+		boolean exists = modifier.exists();
+		// then
+		assertThat(exists).isTrue();
+	}
+
+	@Test
+	public void doeNotExistsIfIsntAvailable() throws ClassNotFoundException {
+		// given
+		doThrow(ClassNotFoundException.class).when(modifier).getSensitivityWatchEventModifierClass();
+		// when
+		boolean exists = modifier.exists();
+		// then
+		assertThat(exists).isFalse();
+	}
+
+	public enum SensitivityModifier implements WatchEvent.Modifier {
+		HIGH, MEDIUM, LOW;
+	}
+
+	@Test
+	public void getNullIfClassAvailableButConstantIsNot() throws ClassNotFoundException {
+		// given
+		doReturn(SensitivityModifierWithoutHigh.class).when(modifier).getSensitivityWatchEventModifierClass();
+		// when
+		Modifier highSensitivity = modifier.get();
+		// then
+		assertThat(highSensitivity).isNull();
+	}
+
+	public enum SensitivityModifierWithoutHigh implements WatchEvent.Modifier {
+		MEDIUM, LOW;
+	}
+	
+	@Test
+	public void getNullIfClassIsNotAvailable() throws ClassNotFoundException {
+		// given
+		doThrow(ClassNotFoundException.class).when(modifier).getSensitivityWatchEventModifierClass();
+		// when
+		Modifier highSensitivity = modifier.get();
+		// then
+		assertThat(highSensitivity).isNull();
+	}
+
+	public class TestableHighSensitivityRegistrar extends HighSensitivityRegistrar {
+
+		@Override
+		public boolean isMac() {
+			return super.isMac();
+		}
+
+		@Override
+		public Class<Modifier> getSensitivityWatchEventModifierClass() throws ClassNotFoundException {
+			return super.getSensitivityWatchEventModifierClass();
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
depends on #131 which has to me merged first.

## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Use high sensitivity when polling for filesystem changes on MacOS
(see https://bugs.openjdk.java.net/browse/JDK-7133447, https://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else)
## Was the change discussed in an issue?
fixes #127
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
