### PR TITLE
gradle: replaced older 'apply plugin' by plugin ids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,14 @@
 plugins {
     id "org.jetbrains.intellij" version "0.4.10"
     id "com.adarshr.test-logger" version "1.7.0"
+    id "idea"
+    id "java"
+    id "jacoco"
 }
 
 repositories {
     mavenCentral()
 }
-
-apply plugin: 'idea'
-apply plugin: 'org.jetbrains.intellij'
-apply plugin: 'java'
-apply plugin: 'jacoco'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
According to the kotlin docs about gradle ```apply plugin``` and ```plugins { id ... }``` in gradle.build are equivalent. Read here: https://kotlinlang.org/docs/reference/using-gradle.html#targeting-the-jvm
> the plugin can be applied using the Gradle plugins DSL:
>
> `plugins {
>    id "org.jetbrains.kotlin.jvm" version "1.3.50"
> }`
>
> Alternatively, you can use the older apply plugin approach:
>
> `apply plugin: 'kotlin'`
