### PR TITLE
#153: Create Service is not allowed at project level 

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/actions/service/CreateServiceAction.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/actions/service/CreateServiceAction.java
@@ -12,9 +12,12 @@ package org.jboss.tools.intellij.openshift.actions.service;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.Messages;
+import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
 import org.jboss.tools.intellij.openshift.actions.OdoAction;
 import org.jboss.tools.intellij.openshift.tree.LazyMutableTreeNode;
 import org.jboss.tools.intellij.openshift.tree.application.ApplicationNode;
+import org.jboss.tools.intellij.openshift.tree.application.ProjectNode;
 import org.jboss.tools.intellij.openshift.ui.service.CreateServiceDialog;
 import org.jboss.tools.intellij.openshift.utils.odo.Odo;
 import org.jboss.tools.intellij.openshift.utils.UIHelper;
@@ -27,21 +30,28 @@ import java.util.concurrent.CompletableFuture;
 
 public class CreateServiceAction extends OdoAction {
   public CreateServiceAction() {
-    super(ApplicationNode.class);
+    super(ApplicationNode.class, ProjectNode.class);
   }
 
   @Override
   public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Odo odo) {
-    LazyMutableTreeNode applicationNode = (LazyMutableTreeNode) selected;
-    LazyMutableTreeNode projectNode = (LazyMutableTreeNode) applicationNode.getParent();
+    final String applicationName;
+    String projectName;
+    if (selected instanceof ApplicationNode) {
+      applicationName = selected.toString();
+      projectName =  ((LazyMutableTreeNode)selected).getParent().toString();
+    } else { // selected is ProjectNode
+      applicationName = "";
+      projectName = selected.toString();
+    }
     CompletableFuture.runAsync(() -> {
       try {
         List<ServiceTemplate> templates = odo.getServiceTemplates();
         if (!templates.isEmpty()) {
-          CreateServiceDialog dialog = UIHelper.executeInUI(() -> showDialog(templates));
+          CreateServiceDialog dialog = UIHelper.executeInUI(() -> showDialog(templates, applicationName));
           if (dialog.isOK()) {
-            createService(odo, projectNode.toString(), applicationNode.toString(), dialog);
-            applicationNode.reload();
+            createService(odo, projectName, dialog.getApplication(), dialog);
+            ((LazyMutableTreeNode)selected).reload();
           }
         } else {
           UIHelper.executeInUI(() -> Messages.showWarningDialog("No templates available", "Create service"));
@@ -56,9 +66,12 @@ public class CreateServiceAction extends OdoAction {
     odo.createService(project, application, dialog.getServiceTemplate().getName(), dialog.getServiceTemplate().getPlan(), dialog.getName());
   }
 
-  protected CreateServiceDialog showDialog(List<ServiceTemplate> templates) {
+  protected CreateServiceDialog showDialog(List<ServiceTemplate> templates, String application) {
     CreateServiceDialog dialog = new CreateServiceDialog(null);
     dialog.setServiceTemplates(templates.toArray(new ServiceTemplate[templates.size()]));
+    if (StringUtils.isNotEmpty(application)) {
+      dialog.setApplication(application);
+    }
     dialog.show();
     return dialog;
   }

--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/service/CreateServiceDialog.form
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/service/CreateServiceDialog.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -43,6 +43,22 @@
           <component id="63fb4" class="javax.swing.JComboBox" binding="serviceTemplatesComboBox">
             <constraints>
               <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="50b4a" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Application:"/>
+            </properties>
+          </component>
+          <component id="5dee7" class="javax.swing.JTextField" binding="applicationTextField">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
             </constraints>
             <properties/>
           </component>

--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/service/CreateServiceDialog.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/service/CreateServiceDialog.java
@@ -27,6 +27,7 @@ public class CreateServiceDialog extends DialogWrapper {
     private JPanel contentPane;
     private JTextField nameField;
     private JComboBox serviceTemplatesComboBox;
+    private JTextField applicationTextField;
 
     public CreateServiceDialog(Component parent) {
         super(null, false, IdeModalityType.IDE);
@@ -49,7 +50,6 @@ public class CreateServiceDialog extends DialogWrapper {
             }
         });
         serviceTemplatesComboBox.setModel(new DefaultComboBoxModel(serviceTemplates));
-        serviceTemplatesComboBox.setSelectedIndex(-1);
         serviceTemplatesComboBox.setSelectedIndex(0);
     }
 
@@ -68,13 +68,19 @@ public class CreateServiceDialog extends DialogWrapper {
         if (nameField.getText().length() == 0) {
             validations.add(new ValidationInfo("Name must be provided", nameField));
         }
+        if (applicationTextField.getText().length() == 0) {
+            validations.add(new ValidationInfo("Application must be provided", applicationTextField));
+        }
         return validations;
     }
 
-    public static void main(String[] args) {
-        CreateServiceDialog dialog = new CreateServiceDialog(null);
-        dialog.show();
-        System.exit(0);
+    public void setApplication(String application){
+        applicationTextField.setText(application);
+        applicationTextField.setEditable(false);
+    }
+
+    public String getApplication(){
+        return applicationTextField.getText();
     }
 
     {

--- a/src/test/java/org/jboss/tools/intellij/openshift/actions/service/CreateServiceActionTest.java
+++ b/src/test/java/org/jboss/tools/intellij/openshift/actions/service/CreateServiceActionTest.java
@@ -32,4 +32,9 @@ public class CreateServiceActionTest extends ActionTest {
   protected void verifyApplication(boolean visible) {
     assertTrue(visible);
   }
+
+  @Override
+  protected void verifyProject(boolean visible) {
+    assertTrue(visible);
+  }
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
adding 'New service' action on project level, with application creation if needed.

## Was the change discussed in an issue?
fixes #153

## How to test changes?
unit tests added
Manual Tests using UI can be performed with the following scenarios :
when project is selected, new service is available as context menu and then service dialog shows with application text field editable. then if application is a new one, service is created under this application node. if application node already exists, service is created under this existing application node.
when application is selected, new service is available in context menu and then service dialog shows with application text field not editable. service is then created under the selected application.

