### PR TITLE
#119 : fix open console action

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ task integrationTest(type: Test) {
 }
 
 dependencies {
-    compile 'io.fabric8:openshift-client:4.8.0'
-    compile 'io.fabric8:servicecatalog-client:4.8.0'
+    compile 'io.fabric8:openshift-client:4.9.1'
+    compile 'io.fabric8:servicecatalog-client:4.9.1'
     compile 'org.apache.commons:commons-compress:1.19'
     compile 'org.apache.commons:commons-exec:1.3'
     compile 'org.apache.commons:commons-lang3:3.9'

--- a/src/main/java/org/jboss/tools/intellij/openshift/Constants.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/Constants.java
@@ -32,6 +32,11 @@ public class Constants {
     public static final String OCP4_CONFIG_NAMESPACE = "openshift-config-managed";
     public static final String OCP4_CONSOLE_PUBLIC_CONFIG_MAP_NAME = "console-public";
     public static final String OCP4_CONSOLE_URL_KEY_NAME = "consoleURL";
+
+    public static final String OCP3_CONFIG_NAMESPACE = "openshift-web-console";
+    public static final String OCP3_WEBCONSOLE_CONFIG_MAP_NAME = "webconsole-config";
+    public static final String OCP3_WEBCONSOLE_YAML_FILE_NAME = "webconsole-config.yaml";
+
     /**
      * Home sub folder for the plugin
      */


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Use new version of openshift-client to determine the configMap to request to retrieve the console URL. 

## Was the change discussed in an issue?
fixes #119 

## How to test changes?
tested with :
- remote openshift 3.11 cluster as user
- local minishift 3.11 as user and as admin
- local crc 4.2 as user and as admin

ALL test should open the console webpage without errors
