### PR TITLE
Rework ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew integrationTest
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-integration-test-reports
+          path: build/test-results
 
   build-macos:
     runs-on: macos-latest
@@ -65,7 +69,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        continue-on-error: true
         run: ./gradlew build
 
   build-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ubuntu-test-reports
+          path: build/test-results
 
   openshift-integration-tests:
     runs-on: ubuntu-latest
@@ -70,6 +74,10 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macos-test-reports
+          path: build/test-results
 
   build-windows:
     runs-on: windows-latest
@@ -84,3 +92,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-test-reports
+          path: build/test-results

--- a/.github/workflows/publish_reports.yml
+++ b/.github/workflows/publish_reports.yml
@@ -20,21 +20,73 @@ jobs:
                 repo: context.repo.repo,
                 run_id: ${{github.event.workflow_run.id}},
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            var linux-integration-test-reports-artifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "linux-integration-test-reports"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var windows-test-reports-artifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "windows-test-reports"
+            })[0];
+            var macos-test-reports-artifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "macos-test-reports"
+            })[0];
+            var ubuntu-test-reports-artifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "ubuntu-test-reports"
+            })[0];
+            var download-linux-integration-test = await github.actions.downloadArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
+              artifact_id: linux-integration-test-reports-artifact.id,
+              archive_format: 'zip',
+            });
+            var download-ubuntu-test = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: ubuntu-test-reports-artifact.id,
+              archive_format: 'zip',
+            });
+            var download-windows-test = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: windows-test-reports-artifact.id,
+              archive_format: 'zip',
+            });
+            var download-macos-test = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: macos-test-reports-artifact.id,
               archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/reports.zip', Buffer.from(download.data));
-      - run: unzip reports.zip
-      - name : Publish Integration tests reports
+            fs.writeFileSync('${{github.workspace}}/linux-integration-test-reports.zip', Buffer.from(download-linux-integration-test.data));
+            fs.writeFileSync('${{github.workspace}}/ubuntu-test-reports.zip', Buffer.from(download-ubuntu-test.data));
+            fs.writeFileSync('${{github.workspace}}/macos-test-reports.zip', Buffer.from(download-macos-test.data));
+            fs.writeFileSync('${{github.workspace}}/windows-test-reports.zip', Buffer.from(download-windows-test.data));
+      - run: |
+          unzip linux-integration-test-reports.zip -d ${{github.workspace}}/linux-integration-test-reports/
+          unzip ubuntu-test-reports.zip -d ${{github.workspace}}/ubuntu-test-reports/
+          unzip macos-test-reports.zip -d ${{github.workspace}}/macos-test-reports/
+          unzip windows-test-reports.zip -d ${{github.workspace}}/windows-test-reports/
+      - name : Publish MacOS tests reports
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
-          report_paths: '**/TEST-*.xml'
+          report_paths: '${{github.workspace}}/macos-test-reports/**/TEST-*.xml'
+          commit: ${{github.event.workflow_run.event.commit}}
+      - name: Publish Windows tests reports
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          report_paths: '${{github.workspace}}/windows-test-reports/**/TEST-*.xml'
+          commit: ${{github.event.workflow_run.event.commit}}
+      - name: Publish Ubuntu tests reports
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          report_paths: '${{github.workspace}}/ubuntu-test-reports/**/TEST-*.xml'
+          commit: ${{github.event.workflow_run.event.commit}}
+      - name: Publish Integration tests reports
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          report_paths: '${{github.workspace}}/linux-integration-test-reports/**/TEST-*.xml'
           commit: ${{github.event.workflow_run.event.commit}}

--- a/.github/workflows/publish_reports.yml
+++ b/.github/workflows/publish_reports.yml
@@ -1,0 +1,40 @@
+name: Publish reports
+
+on:
+  workflow_run:
+    workflows: ["Java CI with Gradle"]
+    types:
+      - completed
+
+jobs:
+  publish:
+    name: Publish Test Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{github.event.workflow_run.id}},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "linux-integration-test-reports"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/reports.zip', Buffer.from(download.data));
+      - run: unzip reports.zip
+      - name : Publish Integration tests reports
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          report_paths: '**/TEST-*.xml'
+          commit: ${{github.event.workflow_run.event.commit}}


### PR DESCRIPTION
use workflow_run to publish tests reports

Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>

## What is the purpose of this change? What does it change?
when pull request or push on master are performed, a new workflow is run in order to extract the test results from the integrationTest performed by the Java CI workflow. this is to workaround security issues that a new workflow with workflow_run event needs to be created.

## Was the change discussed in an issue?
fixes #???

## How to test changes?
