### PR TITLE
fix jenkinsFile to switch to jdk11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 node('rhel7'){
 	def javaHome = tool 'openjdk-11'
-	env.JAVA_HOME = "${mvnHome}/bin"
+	env.JAVA_HOME = "${javaHome}/bin"
 
 	stage('Checkout repo') {
 		deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 #!/usr/bin/env groovy
 
 node('rhel7'){
+	tools {
+		jdk 'openjdk-11'
+	}
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/redhat-developer/intellij-openshift-connector',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 node('rhel7'){
 	def javaHome = tool 'openjdk-11'
-	env.JAVA_HOME = "${javaHome}/bin"
+	env.JAVA_HOME = "${javaHome}"
 
 	stage('Checkout repo') {
 		deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
 node('rhel7'){
-	tools {
-		jdk 'openjdk-11'
-	}
+	def javaHome = tool 'openjdk-11'
+	env.JAVA_HOME = "${mvnHome}/bin"
+
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/redhat-developer/intellij-openshift-connector',


### PR DESCRIPTION
Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>

## What is the purpose of this change? What does it change?
fix release build that fails due to 2020.3 requirements to use java11

## Was the change discussed in an issue?
fixes #???


## How to test changes?
<!-- Please describe the steps to test the PR -->
