### PR TITLE
chore: auto archive Jenkins release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,8 @@ node('rhel7'){
 					stage("Promote the build to stable") {
 						def zip = findFiles(glob: '**/*.zip')
 						sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${zip[0].path} ${UPLOAD_LOCATION}/stable/intellij-openshift-connector/"
+						currentBuild.keepLog = true
+						currentBuild.description = "${version}"
 					}
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

## What is the purpose of this change? What does it change?
Ensure Jenkins builds are auto archived and labelled when releasing

## Was the change discussed in an issue?
fixes #???
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
