### PR TITLE
chore: fix integration tests on Kube clusters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           version: v0.11.1
       - name: Setup cluster
         run: |
-          curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.18.3/install.sh | bash -s v0.18.3
+          curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.19.1/install.sh | bash -s v0.19.1
           kubectl create -f https://operatorhub.io/install/cloud-native-postgresql.yaml
           nb=`kubectl get pods -n operators --no-headers --ignore-not-found | grep postgresql-operator | grep Running | wc -l`
           echo -n "Waiting for operator to show up "

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ plugins {
 }
 
 repositories {
+    maven { url 'https://repository.jboss.org' }
     mavenLocal()
     mavenCentral()
-    maven { url 'https://repository.jboss.org' }
 }
 
 sourceCompatibility = '1.8'

--- a/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliApplicationTest.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliApplicationTest.java
@@ -48,7 +48,7 @@ public class OdoCliApplicationTest extends OdoCliTest {
     }
 
     @Test
-    public void checkListApplications() throws IOException, InterruptedException {
+    public void checkListApplications() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         String application = APPLICATION_PREFIX + random.nextInt();
         String component = COMPONENT_PREFIX + random.nextInt();

--- a/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliCatalogTest.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliCatalogTest.java
@@ -16,14 +16,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.with;
 import static org.junit.Assert.assertTrue;
 
 public class OdoCliCatalogTest extends OdoCliTest {
 
     @Test
-    public void checkGetComponentTypes() throws IOException, InterruptedException {
+    public void checkGetComponentTypes() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         try {
             createProject(project);
@@ -35,7 +34,7 @@ public class OdoCliCatalogTest extends OdoCliTest {
     }
 
     @Test
-    public void checkGetServiceTemplates() throws IOException, InterruptedException {
+    public void checkGetServiceTemplates() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         try {
             createProject(project);
@@ -48,13 +47,13 @@ public class OdoCliCatalogTest extends OdoCliTest {
     }
 
     @Test
-    public void checkMultiPlansServiceTemplates() throws IOException, InterruptedException {
+    public void checkMultiPlansServiceTemplates() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         try {
             createProject(project);
             //After a namespace is created the cluster wide operators takes time to appear
             //in installed state into the namespace
-            with().pollDelay(10, TimeUnit.SECONDS).await().atMost(10, TimeUnit.MINUTES).until(() -> odo.getServiceTemplates().stream().filter(template -> template.getCRDs().size() > 1).count() > 0);
+            with().pollDelay(10, TimeUnit.SECONDS).await().atMost(10, TimeUnit.MINUTES).until(() -> odo.getServiceTemplates().stream().anyMatch(template -> template.getCRDs().size() > 1));
         } finally {
             odo.deleteProject(project);
         }

--- a/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliProjectTest.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliProjectTest.java
@@ -21,7 +21,7 @@ public class OdoCliProjectTest extends OdoCliTest {
 
 
     @Test
-    public void checkCreateProject() throws IOException, InterruptedException {
+    public void checkCreateProject() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         try {
             createProject(project);
@@ -31,7 +31,7 @@ public class OdoCliProjectTest extends OdoCliTest {
     }
 
     @Test
-    public void checkListProjects() throws IOException, InterruptedException {
+    public void checkListProjects() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         try {
             createProject(project);

--- a/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliRegistryTest.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliRegistryTest.java
@@ -26,9 +26,7 @@ public class OdoCliRegistryTest extends OdoCliTest {
         try {
             odo.createDevfileRegistry(registryName, "https://registry.devfile.io", null);
         } finally {
-            try {
-                odo.deleteDevfileRegistry(registryName);
-            } catch (IOException e) {}
+            odo.deleteDevfileRegistry(registryName);
         }
     }
 

--- a/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliServiceTest.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/utils/odo/OdoCliServiceTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 public class OdoCliServiceTest extends OdoCliTest {
 
     @Test
-    public void checkCreateService() throws IOException, InterruptedException {
+    public void checkCreateService() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         String application = APPLICATION_PREFIX + random.nextInt();
         String service = SERVICE_PREFIX + random.nextInt();
@@ -38,7 +38,7 @@ public class OdoCliServiceTest extends OdoCliTest {
 
     @Test
     @Ignore("getServiceTemplate not implemented")
-    public void checkCreateServiceAndGetTemplate() throws IOException, InterruptedException {
+    public void checkCreateServiceAndGetTemplate() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         String application = APPLICATION_PREFIX + random.nextInt();
         String service = SERVICE_PREFIX + random.nextInt();
@@ -56,7 +56,7 @@ public class OdoCliServiceTest extends OdoCliTest {
     }
 
     @Test
-    public void checkCreateDeleteService() throws IOException, InterruptedException {
+    public void checkCreateDeleteService() throws IOException {
         String project = PROJECT_PREFIX + random.nextInt();
         String application = APPLICATION_PREFIX + random.nextInt();
         String service = SERVICE_PREFIX + random.nextInt();


### PR DESCRIPTION
Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>

## What is the purpose of this change? What does it change?
improved integration tests for kube clusters. automatically ignore not working tests when ran with a kube cluster

## Was the change discussed in an issue?
part of movingto ube/ocp4 

## How to test changes?
