### PR TITLE
chore: Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'gradle'
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 #v0.5.0
         name: Start cluster
         with:
           version: v0.11.1

--- a/.github/workflows/conventionalCheck.yml
+++ b/.github/workflows/conventionalCheck.yml
@@ -11,6 +11,6 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.1.0
+      - uses: amannn/action-semantic-pull-request@d2ab30dcffc66150340abb5b947d518a3c3ce9cb #v3.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_reports.yml
+++ b/.github/workflows/publish_reports.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           find . -name '*.zip' -exec sh -c 'unzip -d "${1%.*}" "$1"' _ {} \;
       - name: Publish aggregated tests reports
-        uses: scacap/action-surefire-report@v1
+        uses: scacap/action-surefire-report@4cbb611f23a9b5a030c73c2b32190a80983956ed #v1
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           report_paths: '${{github.workspace}}/*test-reports/**/TEST-*.xml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Simple conventional changelog
-        uses: lstocchi/simple-conventional-changelog@0.0.11
+        uses: lstocchi/simple-conventional-changelog@13071c09073f5deddf03d44d9af6a8b0f81ef227 #0.0.11
         id: changelog
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
