### PR TITLE
chore(skip-release): Prepare for 1.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion=IU-2021.2
-projectVersion=1.4.0-SNAPSHOT
+projectVersion=1.4.0
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,11 @@
     ]]></description>
 
   <change-notes><![CDATA[
+  <p><b>1.4.0</b></p>
+  <ul>
+  <li>Support dev on Podman, see <a href=", see <a href="https://odo.dev/blog/local-container-development-with-podman-and-odo">this page</a></li>">this page for reference</a></li>
+  <li>Updated dependencies</li>
+  </ul>
   <p><b>1.3.0</b></p>
   <ul>
   <li>Switch to odo 3.9.0</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,7 +19,7 @@
   <change-notes><![CDATA[
   <p><b>1.4.0</b></p>
   <ul>
-  <li>Support dev on Podman, see <a href=", see <a href="https://odo.dev/blog/local-container-development-with-podman-and-odo">this page</a></li>">this page for reference</a></li>
+  <li>Run applications in dev mode on Podman. See <a href=", see <a href="https://odo.dev/blog/local-container-development-with-podman-and-odo">this page</a></li>">this page for reference</a></li>
   <li>Updated dependencies</li>
   </ul>
   <p><b>1.3.0</b></p>


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Prepare for 1.4.0 https://github.com/redhat-developer/intellij-openshift-connector/milestone/36

## Was the change discussed in an issue?


## How to test changes?

