### PR TITLE
chore(skip-release): Prepare for 1.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion=IU-2021.2
-projectVersion=1.4.0
+projectVersion=1.5.0
 jetBrainsToken=invalid
 jetBrainsChannel=stable


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Prepare for 1.5.0 https://github.com/redhat-developer/intellij-openshift-connector/milestone/37

## Was the change discussed in an issue?

## How to test changes?

