### PR TITLE
docs: add repository map to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Sonar Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=redhat-developer_intellij-openshift-connector&metric=alert_status)](https://sonarcloud.io/dashboard?id=redhat-developer_intellij-openshift-connector)
 [![JetBrains plugins][plugin-version-svg]][plugin-repo]
 [![JetBrains plugins][plugin-downloads-svg]][plugin-repo]
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/redhatdeveloperintellijopenshiftconnector/)
 
 [![Gitter](https://badges.gitter.im/redhat-developer/openshift-connector.svg)](https://gitter.im/redhat-developer/openshift-connector)
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/redhatdeveloperintellijopenshiftconnector/). Built directly from source and updated on schedule. In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.

## Was the change discussed in an issue?
Documentation-only change. Intended to simplify developer's introduction to the project.

## How to test changes?
README.md is the only document affected
