### PR TITLE
feat: Change job trigger to pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: Java CI with Gradle
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Triggering job **Java CI with Gradle** using **pull_request_target** instead of pull_request.

## Was the change discussed in an issue?
<!-- Please do Link issues here. -->
This change is needed for correct function of GitHub secrets, which are used in #563