### PR TITLE
fix: offer 'Open Helm Charts' on project node (was: cluster)(#676)

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/actions/helm/OpenHelmChartsAction.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/actions/helm/OpenHelmChartsAction.java
@@ -15,6 +15,8 @@ import com.intellij.openapi.project.Project;
 import org.jboss.tools.intellij.openshift.actions.HelmAction;
 import org.jboss.tools.intellij.openshift.telemetry.TelemetryService;
 import org.jboss.tools.intellij.openshift.tree.application.ApplicationsRootNode;
+import org.jboss.tools.intellij.openshift.tree.application.NamespaceNode;
+import org.jboss.tools.intellij.openshift.tree.application.ParentableNode;
 import org.jboss.tools.intellij.openshift.ui.helm.ChartsDialog;
 import org.jboss.tools.intellij.openshift.utils.helm.Helm;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +26,8 @@ public class OpenHelmChartsAction extends HelmAction {
     @Override
     public void actionPerformedOnSelectedObject(AnActionEvent anActionEvent, Object selected, @NotNull Helm helm) {
         Project project = getEventProject(anActionEvent);
-        ChartsDialog dialog = new ChartsDialog((ApplicationsRootNode) selected, helm, project);
+        ApplicationsRootNode rootNode = ((ParentableNode<?>) selected).getRoot();
+        ChartsDialog dialog = new ChartsDialog(rootNode, helm, project);
         sendTelemetryResults(TelemetryService.TelemetryResult.SUCCESS);
         dialog.show();
     }
@@ -36,7 +39,6 @@ public class OpenHelmChartsAction extends HelmAction {
 
     @Override
     public boolean isVisible(Object selected) {
-        return (selected instanceof ApplicationsRootNode)
-          && ((ApplicationsRootNode) selected).isLogged();
+        return selected instanceof NamespaceNode;
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -282,9 +282,6 @@
       <separator/>
       <action class="org.jboss.tools.intellij.openshift.actions.cluster.OpenConsoleAction" id="org.jboss.tools.intellij.openshift.actions.cluster.OpenConsoleAction" text="Open Console Dashboard"/>
       <separator/>
-      <!-- helm -->
-      <action class="org.jboss.tools.intellij.openshift.actions.helm.OpenHelmChartsAction" id="org.jboss.tools.intellij.openshift.actions.helm.OpenHelmChartsAction" text="Open Helm Charts"/>
-      <separator/>
       <action class="org.jboss.tools.intellij.openshift.actions.cluster.RefreshAction" id="org.jboss.tools.intellij.openshift.actions.cluster.RefreshAction" text="Refresh"/>
       <separator/>
       <action id="org.jboss.tools.intellij.openshift.actions.OpenGettingStartedAction"
@@ -324,6 +321,10 @@
       <action class="org.jboss.tools.intellij.openshift.actions.binding.DeleteBindingAction" id="org.jboss.tools.intellij.openshift.actions.binding.DeleteBindingAction" text="Delete"/>
       <!-- project level -->
       <action class="org.jboss.tools.intellij.openshift.actions.project.DeleteProjectAction" id="org.jboss.tools.intellij.openshift.actions.project.DeleteProjectAction" text="Delete"/>
+      <separator/>
+      <!-- helm -->
+      <action class="org.jboss.tools.intellij.openshift.actions.helm.OpenHelmChartsAction" id="org.jboss.tools.intellij.openshift.actions.helm.OpenHelmChartsAction" text="Open Helm Charts"/>
+      <separator/>
       <!-- registry management -->
       <action class="org.jboss.tools.intellij.openshift.actions.registry.CreateRegistryAction" id="org.jboss.tools.intellij.openshift.actions.registry.CreateRegistryAction" text="New registry"/>
       <action class="org.jboss.tools.intellij.openshift.actions.registry.DeleteRegistryAction" id="org.jboss.tools.intellij.openshift.actions.registry.DeleteRegistryAction" text="Delete"/>

--- a/src/test/java/org/jboss/tools/intellij/openshift/actions/helm/OpenHelmChartsActionTest.java
+++ b/src/test/java/org/jboss/tools/intellij/openshift/actions/helm/OpenHelmChartsActionTest.java
@@ -21,12 +21,6 @@ public class OpenHelmChartsActionTest extends ActionTest {
 
   @Override
   protected void verifyProject(boolean visible) {
-    assertFalse(visible);
-  }
-
-  @Override
-  protected void verifyLoggedInCluster(boolean visible) {
     assertTrue(visible);
   }
-
 }


### PR DESCRIPTION
fixes #676 

<img width="459" alt="image" src="https://github.com/redhat-developer/intellij-openshift-connector/assets/25126/ff5975d8-1e1b-4599-bbf6-1e2308ff7d34">
