### PR TITLE
chore(skip-release): Create dependabot.yml for automatic updte of git…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
…hub actions versions

## What is the purpose of this change? What does it change?
automatically check for versions update for github actions. 
for example, currently there is a deprecation notice to move to latest node 20 on actions, and github already released updates for checkout/upolad, ...

## Was the change discussed in an issue?
see https://docs.github.com/fr/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates for ref

## How to test changes?

