### PR TITLE
refactor: bump openshift-client 6.12 (#758)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ intellij {
             'com.intellij.css',
             'yaml',
             'com.redhat.devtools.intellij.telemetry:1.1.0.52',
-            'com.redhat.devtools.intellij.kubernetes:1.2.3.294'
+            'com.redhat.devtools.intellij.kubernetes:1.3.0'
     ]
 	updateSinceUntilBuild = false
 }
@@ -137,10 +137,10 @@ tasks.register('copyKey', Copy) {
 
 dependencies {
     implementation(
-            'io.fabric8:openshift-client:6.4.1',
+            'io.fabric8:openshift-client:6.12.0',
             'org.apache.commons:commons-compress:1.26.1',
             'org.apache.commons:commons-exec:1.4.0',
-            'com.redhat.devtools.intellij:intellij-common:1.9.4-SNAPSHOT',
+            'com.redhat.devtools.intellij:intellij-common:1.9.5',
             'io.jsonwebtoken:jjwt-impl:0.12.5',
             'io.jsonwebtoken:jjwt-jackson:0.12.5',
             'org.keycloak:keycloak-installed-adapter:24.0.2',
@@ -150,7 +150,7 @@ dependencies {
             'org.junit.platform:junit-platform-launcher:1.10.2',
             'org.mockito:mockito-core:5.11.0',
             'org.easytesting:fest-assert:1.4',
-            'com.redhat.devtools.intellij:intellij-common:1.9.4-SNAPSHOT:test',
+            'com.redhat.devtools.intellij:intellij-common:1.9.5-SNAPSHOT:test',
             'org.awaitility:awaitility:4.2.1',
             'org.mock-server:mockserver-client-java:5.15.0',
             'org.mock-server:mockserver-netty:5.15.0',


### PR DESCRIPTION
fixes #758 
depends on:
* https://github.com/redhat-developer/intellij-common/issues/210 (intellij-common bumped to same kubernetes-client)
* https://github.com/redhat-developer/intellij-common/pull/220 (intellij-common 1.9.4 to be released)