### PR TITLE
chore: Update devfile schema from 2.0.0 to 2.2.2

### DIFF
--- a/src/main/resources/schemas/devfile.json
+++ b/src/main/resources/schemas/devfile.json
@@ -1,13 +1,18 @@
 {
-  "description": "Devfile describes the structure of a cloud-native workspace and development environment.",
+  "description": "Devfile describes the structure of a cloud-native devworkspace and development environment.",
   "type": "object",
-  "title": "Devfile schema - Version 2.0.0",
+  "title": "Devfile schema - Version 2.2.2",
   "required": [
     "schemaVersion"
   ],
   "properties": {
+    "attributes": {
+      "description": "Map of implementation-dependant free-form YAML attributes.",
+      "type": "object",
+      "additionalProperties": true
+    },
     "commands": {
-      "description": "Predefined, ready-to-use, workspace-related commands",
+      "description": "Predefined, ready-to-use, devworkspace-related commands",
       "type": "array",
       "items": {
         "type": "object",
@@ -27,23 +32,13 @@
           },
           {
             "required": [
-              "vscodeTask"
-            ]
-          },
-          {
-            "required": [
-              "vscodeLaunch"
-            ]
-          },
-          {
-            "required": [
               "composite"
             ]
           }
         ],
         "properties": {
           "apply": {
-            "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+            "description": "Command that consists in applying a given component definition, typically bound to a devworkspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false.",
             "type": "object",
             "required": [
               "component"
@@ -71,7 +66,8 @@
                       "build",
                       "run",
                       "test",
-                      "debug"
+                      "debug",
+                      "deploy"
                     ]
                   }
                 },
@@ -118,7 +114,8 @@
                       "build",
                       "run",
                       "test",
-                      "debug"
+                      "debug",
+                      "deploy"
                     ]
                   }
                 },
@@ -189,14 +186,15 @@
                       "build",
                       "run",
                       "test",
-                      "debug"
+                      "debug",
+                      "deploy"
                     ]
                   }
                 },
                 "additionalProperties": false
               },
               "hotReloadCapable": {
-                "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "description": "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`.\n\nDefault value is `false`",
                 "type": "boolean"
               },
               "label": {
@@ -215,115 +213,13 @@
             "type": "string",
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-          },
-          "vscodeLaunch": {
-            "description": "Command providing the definition of a VsCode launch action",
-            "type": "object",
-            "oneOf": [
-              {
-                "required": [
-                  "uri"
-                ]
-              },
-              {
-                "required": [
-                  "inlined"
-                ]
-              }
-            ],
-            "properties": {
-              "group": {
-                "description": "Defines the group this command is part of",
-                "type": "object",
-                "required": [
-                  "kind"
-                ],
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "type": "string",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ]
-                  }
-                },
-                "additionalProperties": false
-              },
-              "inlined": {
-                "description": "Inlined content of the VsCode configuration",
-                "type": "string"
-              },
-              "uri": {
-                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          "vscodeTask": {
-            "description": "Command providing the definition of a VsCode Task",
-            "type": "object",
-            "oneOf": [
-              {
-                "required": [
-                  "uri"
-                ]
-              },
-              {
-                "required": [
-                  "inlined"
-                ]
-              }
-            ],
-            "properties": {
-              "group": {
-                "description": "Defines the group this command is part of",
-                "type": "object",
-                "required": [
-                  "kind"
-                ],
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "type": "string",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ]
-                  }
-                },
-                "additionalProperties": false
-              },
-              "inlined": {
-                "description": "Inlined content of the VsCode configuration",
-                "type": "string"
-              },
-              "uri": {
-                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
           }
         },
         "additionalProperties": false
       }
     },
     "components": {
-      "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
+      "description": "List of the devworkspace components, such as editor and plugins, user-provided containers, or other types of components",
       "type": "array",
       "items": {
         "type": "object",
@@ -353,7 +249,7 @@
           },
           {
             "required": [
-              "plugin"
+              "image"
             ]
           }
         ],
@@ -364,12 +260,33 @@
             "additionalProperties": true
           },
           "container": {
-            "description": "Allows adding and configuring workspace-related containers",
+            "description": "Allows adding and configuring devworkspace-related containers",
             "type": "object",
             "required": [
               "image"
             ],
             "properties": {
+              "annotation": {
+                "description": "Annotations that should be added to specific resources for this container",
+                "type": "object",
+                "properties": {
+                  "deployment": {
+                    "description": "Annotations to be added to deployment",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "service": {
+                    "description": "Annotations to be added to service",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
               "args": {
                 "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                 "type": "array",
@@ -384,6 +301,12 @@
                   "type": "string"
                 }
               },
+              "cpuLimit": {
+                "type": "string"
+              },
+              "cpuRequest": {
+                "type": "string"
+              },
               "dedicatedPod": {
                 "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
                 "type": "boolean"
@@ -397,13 +320,20 @@
                     "targetPort"
                   ],
                   "properties": {
+                    "annotation": {
+                      "description": "Annotations to be added to Kubernetes Ingress or Openshift Route",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
                     "attributes": {
                       "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
                       "type": "object",
                       "additionalProperties": true
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address.\n\nDefault value is `public`",
                       "type": "string",
                       "default": "public",
                       "enum": [
@@ -414,7 +344,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
+                      "maxLength": 15,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -439,6 +369,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -469,6 +400,9 @@
                 "type": "string"
               },
               "memoryLimit": {
+                "type": "string"
+              },
+              "memoryRequest": {
                 "type": "string"
               },
               "mountSources": {
@@ -507,8 +441,130 @@
             },
             "additionalProperties": false
           },
+          "image": {
+            "description": "Allows specifying the definition of an image for outer loop builds",
+            "type": "object",
+            "required": [
+              "imageName"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "dockerfile"
+                ]
+              }
+            ],
+            "properties": {
+              "autoBuild": {
+                "description": "Defines if the image should be built during startup.\n\nDefault value is `false`",
+                "type": "boolean"
+              },
+              "dockerfile": {
+                "description": "Allows specifying dockerfile type build",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "devfileRegistry"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "git"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "args": {
+                    "description": "The arguments to supply to the dockerfile build.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "buildContext": {
+                    "description": "Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container",
+                    "type": "string"
+                  },
+                  "devfileRegistry": {
+                    "description": "Dockerfile's Devfile Registry source",
+                    "type": "object",
+                    "required": [
+                      "id"
+                    ],
+                    "properties": {
+                      "id": {
+                        "description": "Id in a devfile registry that contains a Dockerfile. The src in the OCI registry required for the Dockerfile build will be downloaded for building the image.",
+                        "type": "string"
+                      },
+                      "registryUrl": {
+                        "description": "Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src. To ensure the Dockerfile gets resolved consistently in different environments, it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "git": {
+                    "description": "Dockerfile's Git source",
+                    "type": "object",
+                    "required": [
+                      "remotes"
+                    ],
+                    "properties": {
+                      "checkoutFrom": {
+                        "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                        "type": "object",
+                        "properties": {
+                          "remote": {
+                            "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "fileLocation": {
+                        "description": "Location of the Dockerfile in the Git repository when using git as Dockerfile src. Defaults to Dockerfile.",
+                        "type": "string"
+                      },
+                      "remotes": {
+                        "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "rootRequired": {
+                    "description": "Specify if a privileged builder pod is required.\n\nDefault value is `false`",
+                    "type": "boolean"
+                  },
+                  "uri": {
+                    "description": "URI Reference of a Dockerfile. It can be a full URL or a relative URI from the current devfile as the base URI.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "imageName": {
+                "description": "Name of the image for the resulting outerloop build",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
           "kubernetes": {
-            "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+            "description": "Allows importing into the devworkspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
             "type": "object",
             "oneOf": [
               {
@@ -523,6 +579,10 @@
               }
             ],
             "properties": {
+              "deployByDefault": {
+                "description": "Defines if the component should be deployed during startup.\n\nDefault value is `false`",
+                "type": "boolean"
+              },
               "endpoints": {
                 "type": "array",
                 "items": {
@@ -532,13 +592,20 @@
                     "targetPort"
                   ],
                   "properties": {
+                    "annotation": {
+                      "description": "Annotations to be added to Kubernetes Ingress or Openshift Route",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
                     "attributes": {
                       "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
                       "type": "object",
                       "additionalProperties": true
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address.\n\nDefault value is `public`",
                       "type": "string",
                       "default": "public",
                       "enum": [
@@ -549,7 +616,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
+                      "maxLength": 15,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -574,6 +641,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -598,7 +666,7 @@
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
-            "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+            "description": "Allows importing into the devworkspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
             "type": "object",
             "oneOf": [
               {
@@ -613,6 +681,10 @@
               }
             ],
             "properties": {
+              "deployByDefault": {
+                "description": "Defines if the component should be deployed during startup.\n\nDefault value is `false`",
+                "type": "boolean"
+              },
               "endpoints": {
                 "type": "array",
                 "items": {
@@ -622,13 +694,20 @@
                     "targetPort"
                   ],
                   "properties": {
+                    "annotation": {
+                      "description": "Annotations to be added to Kubernetes Ingress or Openshift Route",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
                     "attributes": {
                       "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
                       "type": "object",
                       "additionalProperties": true
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address.\n\nDefault value is `public`",
                       "type": "string",
                       "default": "public",
                       "enum": [
@@ -639,7 +718,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
+                      "maxLength": 15,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -664,6 +743,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -681,711 +761,99 @@
             },
             "additionalProperties": false
           },
-          "plugin": {
-            "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+          "volume": {
+            "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
-            "oneOf": [
-              {
-                "required": [
-                  "uri"
-                ]
+            "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean"
               },
-              {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "kubernetes"
-                ]
+              "size": {
+                "description": "Size of the volume",
+                "type": "string"
               }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "dependentProjects": {
+      "description": "Additional projects related to the main project in the devfile, contianing names and sources locations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "git"
+            ]
+          },
+          {
+            "required": [
+              "zip"
+            ]
+          }
+        ],
+        "properties": {
+          "attributes": {
+            "description": "Map of implementation-dependant free-form YAML attributes.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "clonePath": {
+            "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
+            "type": "string"
+          },
+          "git": {
+            "description": "Project's Git source",
+            "type": "object",
+            "required": [
+              "remotes"
             ],
             "properties": {
-              "commands": {
-                "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "id"
-                  ],
-                  "oneOf": [
-                    {
-                      "required": [
-                        "exec"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "apply"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "vscodeTask"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "vscodeLaunch"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "composite"
-                      ]
-                    }
-                  ],
-                  "properties": {
-                    "apply": {
-                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                      "type": "object",
-                      "properties": {
-                        "component": {
-                          "description": "Describes component that will be applied",
-                          "type": "string"
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "type": "object",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "type": "string",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "label": {
-                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "attributes": {
-                      "description": "Map of implementation-dependant free-form YAML attributes.",
-                      "type": "object",
-                      "additionalProperties": true
-                    },
-                    "composite": {
-                      "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                      "type": "object",
-                      "properties": {
-                        "commands": {
-                          "description": "The commands that comprise this composite command",
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "type": "object",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "type": "string",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "label": {
-                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
-                        },
-                        "parallel": {
-                          "description": "Indicates if the sub-commands should be executed concurrently",
-                          "type": "boolean"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "exec": {
-                      "description": "CLI Command executed in an existing component container",
-                      "type": "object",
-                      "properties": {
-                        "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
-                          "type": "string"
-                        },
-                        "component": {
-                          "description": "Describes component to which given action relates",
-                          "type": "string"
-                        },
-                        "env": {
-                          "description": "Optional list of environment variables that have to be set before running the command",
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "name"
-                            ],
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "type": "object",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "type": "string",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "hotReloadCapable": {
-                          "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
-                          "type": "boolean"
-                        },
-                        "label": {
-                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
-                        },
-                        "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "id": {
-                      "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                      "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                    },
-                    "vscodeLaunch": {
-                      "description": "Command providing the definition of a VsCode launch action",
-                      "type": "object",
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ],
-                      "properties": {
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "type": "object",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "type": "string",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "inlined": {
-                          "description": "Inlined content of the VsCode configuration",
-                          "type": "string"
-                        },
-                        "uri": {
-                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "vscodeTask": {
-                      "description": "Command providing the definition of a VsCode Task",
-                      "type": "object",
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ],
-                      "properties": {
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "type": "object",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "type": "string",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "inlined": {
-                          "description": "Inlined content of the VsCode configuration",
-                          "type": "string"
-                        },
-                        "uri": {
-                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "components": {
-                "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name"
-                  ],
-                  "oneOf": [
-                    {
-                      "required": [
-                        "container"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "kubernetes"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "openshift"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "volume"
-                      ]
-                    }
-                  ],
-                  "properties": {
-                    "attributes": {
-                      "description": "Map of implementation-dependant free-form YAML attributes.",
-                      "type": "object",
-                      "additionalProperties": true
-                    },
-                    "container": {
-                      "description": "Allows adding and configuring workspace-related containers",
-                      "type": "object",
-                      "properties": {
-                        "args": {
-                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "command": {
-                          "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "dedicatedPod": {
-                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
-                          "type": "boolean"
-                        },
-                        "endpoints": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "name"
-                            ],
-                            "properties": {
-                              "attributes": {
-                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
-                                "type": "string",
-                                "enum": [
-                                  "public",
-                                  "internal",
-                                  "none"
-                                ]
-                              },
-                              "name": {
-                                "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                              },
-                              "path": {
-                                "description": "Path of the endpoint URL",
-                                "type": "string"
-                              },
-                              "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "https",
-                                  "ws",
-                                  "wss",
-                                  "tcp",
-                                  "udp"
-                                ]
-                              },
-                              "secure": {
-                                "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
-                                "type": "boolean"
-                              },
-                              "targetPort": {
-                                "type": "integer"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        },
-                        "env": {
-                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "name"
-                            ],
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "memoryLimit": {
-                          "type": "string"
-                        },
-                        "mountSources": {
-                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
-                          "type": "boolean"
-                        },
-                        "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
-                          "type": "string"
-                        },
-                        "volumeMounts": {
-                          "description": "List of volumes mounts that should be mounted is this container.",
-                          "type": "array",
-                          "items": {
-                            "description": "Volume that should be mounted to a component container",
-                            "type": "object",
-                            "required": [
-                              "name"
-                            ],
-                            "properties": {
-                              "name": {
-                                "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                              },
-                              "path": {
-                                "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
-                                "type": "string"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "kubernetes": {
-                      "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
-                      "type": "object",
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ],
-                      "properties": {
-                        "endpoints": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "name"
-                            ],
-                            "properties": {
-                              "attributes": {
-                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
-                                "type": "string",
-                                "enum": [
-                                  "public",
-                                  "internal",
-                                  "none"
-                                ]
-                              },
-                              "name": {
-                                "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                              },
-                              "path": {
-                                "description": "Path of the endpoint URL",
-                                "type": "string"
-                              },
-                              "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "https",
-                                  "ws",
-                                  "wss",
-                                  "tcp",
-                                  "udp"
-                                ]
-                              },
-                              "secure": {
-                                "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
-                                "type": "boolean"
-                              },
-                              "targetPort": {
-                                "type": "integer"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        },
-                        "inlined": {
-                          "description": "Inlined manifest",
-                          "type": "string"
-                        },
-                        "uri": {
-                          "description": "Location in a file fetched from a uri.",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "name": {
-                      "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                      "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                    },
-                    "openshift": {
-                      "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
-                      "type": "object",
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ],
-                      "properties": {
-                        "endpoints": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "name"
-                            ],
-                            "properties": {
-                              "attributes": {
-                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
-                                "type": "string",
-                                "enum": [
-                                  "public",
-                                  "internal",
-                                  "none"
-                                ]
-                              },
-                              "name": {
-                                "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                              },
-                              "path": {
-                                "description": "Path of the endpoint URL",
-                                "type": "string"
-                              },
-                              "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "https",
-                                  "ws",
-                                  "wss",
-                                  "tcp",
-                                  "udp"
-                                ]
-                              },
-                              "secure": {
-                                "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
-                                "type": "boolean"
-                              },
-                              "targetPort": {
-                                "type": "integer"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        },
-                        "inlined": {
-                          "description": "Inlined manifest",
-                          "type": "string"
-                        },
-                        "uri": {
-                          "description": "Location in a file fetched from a uri.",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "volume": {
-                      "description": "Allows specifying the definition of a volume shared by several other components",
-                      "type": "object",
-                      "properties": {
-                        "size": {
-                          "description": "Size of the volume",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "id": {
-                "description": "Id in a registry that contains a Devfile yaml file",
-                "type": "string"
-              },
-              "kubernetes": {
-                "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
                 "type": "object",
-                "required": [
-                  "name"
-                ],
                 "properties": {
-                  "name": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
                     "type": "string"
                   },
-                  "namespace": {
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
                     "type": "string"
                   }
                 },
                 "additionalProperties": false
               },
-              "registryUrl": {
-                "type": "string"
-              },
-              "uri": {
-                "description": "Uri of a Devfile yaml file",
-                "type": "string"
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             },
             "additionalProperties": false
           },
-          "volume": {
-            "description": "Allows specifying the definition of a volume shared by several other components",
+          "name": {
+            "description": "Project name",
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          "zip": {
+            "description": "Project's Zip source",
             "type": "object",
             "properties": {
-              "size": {
-                "description": "Size of the volume",
+              "location": {
+                "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
                 "type": "string"
               }
             },
@@ -1400,28 +868,28 @@
       "type": "object",
       "properties": {
         "postStart": {
-          "description": "IDs of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser.",
+          "description": "IDs of commands that should be executed after the devworkspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "postStop": {
-          "description": "IDs of commands that should be executed after stopping the workspace.",
+          "description": "IDs of commands that should be executed after stopping the devworkspace.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "preStart": {
-          "description": "IDs of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
+          "description": "IDs of commands that should be executed before the devworkspace start. Kubernetes-wise, these commands would typically be executed in init containers of the devworkspace POD.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "preStop": {
-          "description": "IDs of commands that should be executed before stopping the workspace.",
+          "description": "IDs of commands that should be executed before stopping the devworkspace.",
           "type": "array",
           "items": {
             "type": "string"
@@ -1434,8 +902,23 @@
       "description": "Optional metadata",
       "type": "object",
       "properties": {
+        "architectures": {
+          "description": "Optional list of processor architectures that the devfile supports, empty list suggests that the devfile can be used on any architecture",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "description": "Architecture describes the architecture type",
+            "type": "string",
+            "enum": [
+              "amd64",
+              "arm64",
+              "ppc64le",
+              "s390x"
+            ]
+          }
+        },
         "attributes": {
-          "description": "Map of implementation-dependant free-form YAML attributes.",
+          "description": "Map of implementation-dependant free-form YAML attributes. Deprecated, use the top-level attributes field instead.",
           "type": "object",
           "additionalProperties": true
         },
@@ -1452,11 +935,27 @@
           "type": "string"
         },
         "icon": {
-          "description": "Optional devfile icon",
+          "description": "Optional devfile icon, can be a URI or a relative path in the project",
+          "type": "string"
+        },
+        "language": {
+          "description": "Optional devfile language",
           "type": "string"
         },
         "name": {
           "description": "Optional devfile name",
+          "type": "string"
+        },
+        "projectType": {
+          "description": "Optional devfile project type",
+          "type": "string"
+        },
+        "provider": {
+          "description": "Optional devfile provider information",
+          "type": "string"
+        },
+        "supportUrl": {
+          "description": "Optional link to a page that provides support information",
           "type": "string"
         },
         "tags": {
@@ -1470,12 +969,16 @@
           "description": "Optional semver-compatible version",
           "type": "string",
           "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        },
+        "website": {
+          "description": "Optional devfile website",
+          "type": "string"
         }
       },
       "additionalProperties": true
     },
     "parent": {
-      "description": "Parent workspace template",
+      "description": "Parent devworkspace template",
       "type": "object",
       "oneOf": [
         {
@@ -1495,6 +998,11 @@
         }
       ],
       "properties": {
+        "attributes": {
+          "description": "Overrides of attributes encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "object",
+          "additionalProperties": true
+        },
         "commands": {
           "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
           "type": "array",
@@ -1516,23 +1024,13 @@
               },
               {
                 "required": [
-                  "vscodeTask"
-                ]
-              },
-              {
-                "required": [
-                  "vscodeLaunch"
-                ]
-              },
-              {
-                "required": [
                   "composite"
                 ]
               }
             ],
             "properties": {
               "apply": {
-                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                "description": "Command that consists in applying a given component definition, typically bound to a devworkspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false.",
                 "type": "object",
                 "properties": {
                   "component": {
@@ -1554,7 +1052,8 @@
                           "build",
                           "run",
                           "test",
-                          "debug"
+                          "debug",
+                          "deploy"
                         ]
                       }
                     },
@@ -1598,7 +1097,8 @@
                           "build",
                           "run",
                           "test",
-                          "debug"
+                          "debug",
+                          "deploy"
                         ]
                       }
                     },
@@ -1661,14 +1161,15 @@
                           "build",
                           "run",
                           "test",
-                          "debug"
+                          "debug",
+                          "deploy"
                         ]
                       }
                     },
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`.\n\nDefault value is `false`",
                     "type": "boolean"
                   },
                   "label": {
@@ -1687,102 +1188,6 @@
                 "type": "string",
                 "maxLength": 63,
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-              },
-              "vscodeLaunch": {
-                "description": "Command providing the definition of a VsCode launch action",
-                "type": "object",
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "inlined"
-                    ]
-                  }
-                ],
-                "properties": {
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "type": "object",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
-                      },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "type": "string",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ]
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "inlined": {
-                    "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
-                  },
-                  "uri": {
-                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "vscodeTask": {
-                "description": "Command providing the definition of a VsCode Task",
-                "type": "object",
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "inlined"
-                    ]
-                  }
-                ],
-                "properties": {
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "type": "object",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
-                      },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "type": "string",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ]
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "inlined": {
-                    "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
-                  },
-                  "uri": {
-                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
               }
             },
             "additionalProperties": false
@@ -1819,7 +1224,7 @@
               },
               {
                 "required": [
-                  "plugin"
+                  "image"
                 ]
               }
             ],
@@ -1830,9 +1235,30 @@
                 "additionalProperties": true
               },
               "container": {
-                "description": "Allows adding and configuring workspace-related containers",
+                "description": "Allows adding and configuring devworkspace-related containers",
                 "type": "object",
                 "properties": {
+                  "annotation": {
+                    "description": "Annotations that should be added to specific resources for this container",
+                    "type": "object",
+                    "properties": {
+                      "deployment": {
+                        "description": "Annotations to be added to deployment",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "service": {
+                        "description": "Annotations to be added to service",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
                   "args": {
                     "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "type": "array",
@@ -1847,6 +1273,12 @@
                       "type": "string"
                     }
                   },
+                  "cpuLimit": {
+                    "type": "string"
+                  },
+                  "cpuRequest": {
+                    "type": "string"
+                  },
                   "dedicatedPod": {
                     "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
                     "type": "boolean"
@@ -1859,13 +1291,20 @@
                         "name"
                       ],
                       "properties": {
+                        "annotation": {
+                          "description": "Annotations to be added to Kubernetes Ingress or Openshift Route",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
                         "attributes": {
                           "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
                           "type": "object",
                           "additionalProperties": true
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address.\n\nDefault value is `public`",
                           "type": "string",
                           "enum": [
                             "public",
@@ -1875,7 +1314,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
+                          "maxLength": 15,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -1899,6 +1338,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -1928,6 +1368,9 @@
                     "type": "string"
                   },
                   "memoryLimit": {
+                    "type": "string"
+                  },
+                  "memoryRequest": {
                     "type": "string"
                   },
                   "mountSources": {
@@ -1965,8 +1408,126 @@
                 },
                 "additionalProperties": false
               },
+              "image": {
+                "description": "Allows specifying the definition of an image for outer loop builds",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "dockerfile"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "autoBuild"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "autoBuild": {
+                    "description": "Defines if the image should be built during startup.\n\nDefault value is `false`",
+                    "type": "boolean"
+                  },
+                  "dockerfile": {
+                    "description": "Allows specifying dockerfile type build",
+                    "type": "object",
+                    "oneOf": [
+                      {
+                        "required": [
+                          "uri"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "devfileRegistry"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "git"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "The arguments to supply to the dockerfile build.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "buildContext": {
+                        "description": "Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container",
+                        "type": "string"
+                      },
+                      "devfileRegistry": {
+                        "description": "Dockerfile's Devfile Registry source",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "Id in a devfile registry that contains a Dockerfile. The src in the OCI registry required for the Dockerfile build will be downloaded for building the image.",
+                            "type": "string"
+                          },
+                          "registryUrl": {
+                            "description": "Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src. To ensure the Dockerfile gets resolved consistently in different environments, it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "git": {
+                        "description": "Dockerfile's Git source",
+                        "type": "object",
+                        "properties": {
+                          "checkoutFrom": {
+                            "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                            "type": "object",
+                            "properties": {
+                              "remote": {
+                                "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                                "type": "string"
+                              },
+                              "revision": {
+                                "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "fileLocation": {
+                            "description": "Location of the Dockerfile in the Git repository when using git as Dockerfile src. Defaults to Dockerfile.",
+                            "type": "string"
+                          },
+                          "remotes": {
+                            "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "rootRequired": {
+                        "description": "Specify if a privileged builder pod is required.\n\nDefault value is `false`",
+                        "type": "boolean"
+                      },
+                      "uri": {
+                        "description": "URI Reference of a Dockerfile. It can be a full URL or a relative URI from the current devfile as the base URI.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "imageName": {
+                    "description": "Name of the image for the resulting outerloop build",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
               "kubernetes": {
-                "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                "description": "Allows importing into the devworkspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                 "type": "object",
                 "oneOf": [
                   {
@@ -1981,6 +1542,10 @@
                   }
                 ],
                 "properties": {
+                  "deployByDefault": {
+                    "description": "Defines if the component should be deployed during startup.\n\nDefault value is `false`",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "type": "array",
                     "items": {
@@ -1989,13 +1554,20 @@
                         "name"
                       ],
                       "properties": {
+                        "annotation": {
+                          "description": "Annotations to be added to Kubernetes Ingress or Openshift Route",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
                         "attributes": {
                           "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
                           "type": "object",
                           "additionalProperties": true
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address.\n\nDefault value is `public`",
                           "type": "string",
                           "enum": [
                             "public",
@@ -2005,7 +1577,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
+                          "maxLength": 15,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2029,6 +1601,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -2053,7 +1626,7 @@
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
-                "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                "description": "Allows importing into the devworkspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                 "type": "object",
                 "oneOf": [
                   {
@@ -2068,6 +1641,10 @@
                   }
                 ],
                 "properties": {
+                  "deployByDefault": {
+                    "description": "Defines if the component should be deployed during startup.\n\nDefault value is `false`",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "type": "array",
                     "items": {
@@ -2076,13 +1653,20 @@
                         "name"
                       ],
                       "properties": {
+                        "annotation": {
+                          "description": "Annotations to be added to Kubernetes Ingress or Openshift Route",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
                         "attributes": {
                           "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
                           "type": "object",
                           "additionalProperties": true
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address.\n\nDefault value is `public`",
                           "type": "string",
                           "enum": [
                             "public",
@@ -2092,7 +1676,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
+                          "maxLength": 15,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2116,6 +1700,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -2133,708 +1718,96 @@
                 },
                 "additionalProperties": false
               },
-              "plugin": {
-                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+              "volume": {
+                "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "id"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "kubernetes"
-                    ]
-                  }
-                ],
                 "properties": {
-                  "commands": {
-                    "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "id"
-                      ],
-                      "oneOf": [
-                        {
-                          "required": [
-                            "exec"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "apply"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "vscodeTask"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "vscodeLaunch"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "composite"
-                          ]
-                        }
-                      ],
-                      "properties": {
-                        "apply": {
-                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                          "type": "object",
-                          "properties": {
-                            "component": {
-                              "description": "Describes component that will be applied",
-                              "type": "string"
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "type": "object",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "type": "string",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ]
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            "label": {
-                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "attributes": {
-                          "description": "Map of implementation-dependant free-form YAML attributes.",
-                          "type": "object",
-                          "additionalProperties": true
-                        },
-                        "composite": {
-                          "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                          "type": "object",
-                          "properties": {
-                            "commands": {
-                              "description": "The commands that comprise this composite command",
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "type": "object",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "type": "string",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ]
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            "label": {
-                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
-                            },
-                            "parallel": {
-                              "description": "Indicates if the sub-commands should be executed concurrently",
-                              "type": "boolean"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "exec": {
-                          "description": "CLI Command executed in an existing component container",
-                          "type": "object",
-                          "properties": {
-                            "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
-                              "type": "string"
-                            },
-                            "component": {
-                              "description": "Describes component to which given action relates",
-                              "type": "string"
-                            },
-                            "env": {
-                              "description": "Optional list of environment variables that have to be set before running the command",
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "required": [
-                                  "name"
-                                ],
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "type": "object",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "type": "string",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ]
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            "hotReloadCapable": {
-                              "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
-                              "type": "boolean"
-                            },
-                            "label": {
-                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
-                            },
-                            "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "id": {
-                          "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                        },
-                        "vscodeLaunch": {
-                          "description": "Command providing the definition of a VsCode launch action",
-                          "type": "object",
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ],
-                          "properties": {
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "type": "object",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "type": "string",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ]
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            "inlined": {
-                              "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
-                            },
-                            "uri": {
-                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "vscodeTask": {
-                          "description": "Command providing the definition of a VsCode Task",
-                          "type": "object",
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ],
-                          "properties": {
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "type": "object",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "type": "string",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ]
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            "inlined": {
-                              "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
-                            },
-                            "uri": {
-                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "additionalProperties": false
-                    }
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean"
                   },
-                  "components": {
-                    "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "name"
-                      ],
-                      "oneOf": [
-                        {
-                          "required": [
-                            "container"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "kubernetes"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "openshift"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "volume"
-                          ]
-                        }
-                      ],
-                      "properties": {
-                        "attributes": {
-                          "description": "Map of implementation-dependant free-form YAML attributes.",
-                          "type": "object",
-                          "additionalProperties": true
-                        },
-                        "container": {
-                          "description": "Allows adding and configuring workspace-related containers",
-                          "type": "object",
-                          "properties": {
-                            "args": {
-                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "command": {
-                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "dedicatedPod": {
-                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
-                              "type": "boolean"
-                            },
-                            "endpoints": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "required": [
-                                  "name"
-                                ],
-                                "properties": {
-                                  "attributes": {
-                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object",
-                                    "additionalProperties": true
-                                  },
-                                  "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
-                                    "type": "string",
-                                    "enum": [
-                                      "public",
-                                      "internal",
-                                      "none"
-                                    ]
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                                  },
-                                  "path": {
-                                    "description": "Path of the endpoint URL",
-                                    "type": "string"
-                                  },
-                                  "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
-                                    "type": "string",
-                                    "enum": [
-                                      "http",
-                                      "https",
-                                      "ws",
-                                      "wss",
-                                      "tcp",
-                                      "udp"
-                                    ]
-                                  },
-                                  "secure": {
-                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
-                                    "type": "boolean"
-                                  },
-                                  "targetPort": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            },
-                            "env": {
-                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "required": [
-                                  "name"
-                                ],
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "memoryLimit": {
-                              "type": "string"
-                            },
-                            "mountSources": {
-                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
-                              "type": "boolean"
-                            },
-                            "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
-                              "type": "string"
-                            },
-                            "volumeMounts": {
-                              "description": "List of volumes mounts that should be mounted is this container.",
-                              "type": "array",
-                              "items": {
-                                "description": "Volume that should be mounted to a component container",
-                                "type": "object",
-                                "required": [
-                                  "name"
-                                ],
-                                "properties": {
-                                  "name": {
-                                    "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                                  },
-                                  "path": {
-                                    "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "kubernetes": {
-                          "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
-                          "type": "object",
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ],
-                          "properties": {
-                            "endpoints": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "required": [
-                                  "name"
-                                ],
-                                "properties": {
-                                  "attributes": {
-                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object",
-                                    "additionalProperties": true
-                                  },
-                                  "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
-                                    "type": "string",
-                                    "enum": [
-                                      "public",
-                                      "internal",
-                                      "none"
-                                    ]
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                                  },
-                                  "path": {
-                                    "description": "Path of the endpoint URL",
-                                    "type": "string"
-                                  },
-                                  "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
-                                    "type": "string",
-                                    "enum": [
-                                      "http",
-                                      "https",
-                                      "ws",
-                                      "wss",
-                                      "tcp",
-                                      "udp"
-                                    ]
-                                  },
-                                  "secure": {
-                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
-                                    "type": "boolean"
-                                  },
-                                  "targetPort": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            },
-                            "inlined": {
-                              "description": "Inlined manifest",
-                              "type": "string"
-                            },
-                            "uri": {
-                              "description": "Location in a file fetched from a uri.",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "name": {
-                          "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                          "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                        },
-                        "openshift": {
-                          "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
-                          "type": "object",
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ],
-                          "properties": {
-                            "endpoints": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "required": [
-                                  "name"
-                                ],
-                                "properties": {
-                                  "attributes": {
-                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object",
-                                    "additionalProperties": true
-                                  },
-                                  "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
-                                    "type": "string",
-                                    "enum": [
-                                      "public",
-                                      "internal",
-                                      "none"
-                                    ]
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                                  },
-                                  "path": {
-                                    "description": "Path of the endpoint URL",
-                                    "type": "string"
-                                  },
-                                  "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
-                                    "type": "string",
-                                    "enum": [
-                                      "http",
-                                      "https",
-                                      "ws",
-                                      "wss",
-                                      "tcp",
-                                      "udp"
-                                    ]
-                                  },
-                                  "secure": {
-                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
-                                    "type": "boolean"
-                                  },
-                                  "targetPort": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            },
-                            "inlined": {
-                              "description": "Inlined manifest",
-                              "type": "string"
-                            },
-                            "uri": {
-                              "description": "Location in a file fetched from a uri.",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "volume": {
-                          "description": "Allows specifying the definition of a volume shared by several other components",
-                          "type": "object",
-                          "properties": {
-                            "size": {
-                              "description": "Size of the volume",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "additionalProperties": false
-                    }
-                  },
-                  "id": {
-                    "description": "Id in a registry that contains a Devfile yaml file",
+                  "size": {
+                    "description": "Size of the volume",
                     "type": "string"
-                  },
-                  "kubernetes": {
-                    "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "dependentProjects": {
+          "description": "Overrides of dependentProjects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "git"
+                ]
+              },
+              {
+                "required": [
+                  "zip"
+                ]
+              }
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Map of implementation-dependant free-form YAML attributes.",
+                "type": "object",
+                "additionalProperties": true
+              },
+              "clonePath": {
+                "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
+                "type": "string"
+              },
+              "git": {
+                "description": "Project's Git source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
                     "type": "object",
                     "properties": {
-                      "name": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
                         "type": "string"
                       },
-                      "namespace": {
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
                         "type": "string"
                       }
                     },
                     "additionalProperties": false
                   },
-                  "registryUrl": {
-                    "type": "string"
-                  },
-                  "uri": {
-                    "description": "Uri of a Devfile yaml file",
-                    "type": "string"
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
                   }
                 },
                 "additionalProperties": false
               },
-              "volume": {
-                "description": "Allows specifying the definition of a volume shared by several other components",
+              "name": {
+                "description": "Project name",
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "zip": {
+                "description": "Project's Zip source",
                 "type": "object",
                 "properties": {
-                  "size": {
-                    "description": "Size of the volume",
+                  "location": {
+                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
                     "type": "string"
                   }
                 },
@@ -2880,11 +1853,6 @@
               },
               {
                 "required": [
-                  "github"
-                ]
-              },
-              {
-                "required": [
                   "zip"
                 ]
               }
@@ -2919,36 +1887,7 @@
                     "additionalProperties": false
                   },
                   "remotes": {
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "additionalProperties": false
-              },
-              "github": {
-                "description": "Project's GitHub source",
-                "type": "object",
-                "properties": {
-                  "checkoutFrom": {
-                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "type": "object",
-                    "properties": {
-                      "remote": {
-                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                        "type": "string"
-                      },
-                      "revision": {
-                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "remotes": {
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
@@ -2962,13 +1901,6 @@
                 "type": "string",
                 "maxLength": 63,
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-              },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
               },
               "zip": {
                 "description": "Project's Zip source",
@@ -2986,6 +1918,7 @@
           }
         },
         "registryUrl": {
+          "description": "Registry URL to pull the parent devfile from when using id in the parent reference. To ensure the parent devfile gets resolved consistently in different environments, it is recommended to always specify the `registryUrl` when `id` is used.",
           "type": "string"
         },
         "starterProjects": {
@@ -3000,11 +1933,6 @@
               {
                 "required": [
                   "git"
-                ]
-              },
-              {
-                "required": [
-                  "github"
                 ]
               },
               {
@@ -3043,36 +1971,7 @@
                     "additionalProperties": false
                   },
                   "remotes": {
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "additionalProperties": false
-              },
-              "github": {
-                "description": "Project's GitHub source",
-                "type": "object",
-                "properties": {
-                  "checkoutFrom": {
-                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "type": "object",
-                    "properties": {
-                      "remote": {
-                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                        "type": "string"
-                      },
-                      "revision": {
-                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "remotes": {
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
@@ -3107,14 +2006,26 @@
           }
         },
         "uri": {
-          "description": "Uri of a Devfile yaml file",
+          "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
           "type": "string"
+        },
+        "variables": {
+          "description": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
+          "type": "string",
+          "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
         }
       },
       "additionalProperties": false
     },
     "projects": {
-      "description": "Projects worked on in the workspace, containing names and sources locations",
+      "description": "Projects worked on in the devworkspace, containing names and sources locations",
       "type": "array",
       "items": {
         "type": "object",
@@ -3125,11 +2036,6 @@
           {
             "required": [
               "git"
-            ]
-          },
-          {
-            "required": [
-              "github"
             ]
           },
           {
@@ -3171,39 +2077,7 @@
                 "additionalProperties": false
               },
               "remotes": {
-                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          "github": {
-            "description": "Project's GitHub source",
-            "type": "object",
-            "required": [
-              "remotes"
-            ],
-            "properties": {
-              "checkoutFrom": {
-                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                "type": "object",
-                "properties": {
-                  "remote": {
-                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                    "type": "string"
-                  },
-                  "revision": {
-                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "remotes": {
-                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
                 "type": "object",
                 "additionalProperties": {
                   "type": "string"
@@ -3217,13 +2091,6 @@
             "type": "string",
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-          },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "zip": {
             "description": "Project's Zip source",
@@ -3257,11 +2124,6 @@
           {
             "required": [
               "git"
-            ]
-          },
-          {
-            "required": [
-              "github"
             ]
           },
           {
@@ -3303,39 +2165,7 @@
                 "additionalProperties": false
               },
               "remotes": {
-                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          "github": {
-            "description": "Project's GitHub source",
-            "type": "object",
-            "required": [
-              "remotes"
-            ],
-            "properties": {
-              "checkoutFrom": {
-                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                "type": "object",
-                "properties": {
-                  "remote": {
-                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                    "type": "string"
-                  },
-                  "revision": {
-                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "remotes": {
-                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "description": "The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects \u0026 Image Component's Git source can only have at most one remote configured.",
                 "type": "object",
                 "additionalProperties": {
                   "type": "string"
@@ -3367,6 +2197,13 @@
           }
         },
         "additionalProperties": false
+      }
+    },
+    "variables": {
+      "description": "Map of key-value variables used for string replacement in the devfile. Values can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
       }
     }
   },


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

Currently an old devfile schema is used. This leads to schema validation warnings like in the following:

![image](https://github.com/redhat-developer/intellij-openshift-connector/assets/8654480/25a5fae9-3314-470a-b427-2c447801021b)

This is address in this issue and the schema updated to the latest version (2.2.2): https://github.com/devfile/api/blob/v2.2.2/schemas/latest/devfile.json

## Was the change discussed in an issue?
no

## How to test changes?
