### PR TITLE
fix(UItest): extended timeout for login dialog for test stability

### DIFF
--- a/.github/workflows/cluster_integration_ui_tests.yml
+++ b/.github/workflows/cluster_integration_ui_tests.yml
@@ -49,6 +49,7 @@ jobs:
           sleep 10
           ./gradlew clusterIntegrationUITest --continue --no-daemon --info
       - name: Publish tests reports
+        if: always()
         uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 #v1.8.0
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/public_integration_ui_tests.yml
+++ b/.github/workflows/public_integration_ui_tests.yml
@@ -33,6 +33,7 @@ jobs:
           sleep 10
           ./gradlew publicIntegrationUITest --continue --no-daemon
       - name: Publish tests reports
+        if: always()
         uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 #v1.8.0
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/src/it/java/org/jboss/tools/intellij/openshift/test/ui/dialogs/ClusterLoginDialog.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/test/ui/dialogs/ClusterLoginDialog.java
@@ -44,7 +44,7 @@ public class ClusterLoginDialog extends CommonContainerFixture {
         view.openView();
         view.waitForTreeItem(DEVFILE_REGISTRIES, 120, 1);
         view.menuRightClickAndSelect(robot, 0, LOG_IN_TO_CLUSTER);
-        return robot.find(ClusterLoginDialog.class, Duration.ofSeconds(20));
+        return robot.find(ClusterLoginDialog.class, Duration.ofSeconds(60));
     }
 
     public void close() {

--- a/src/it/java/org/jboss/tools/intellij/openshift/test/ui/views/OpenshiftView.java
+++ b/src/it/java/org/jboss/tools/intellij/openshift/test/ui/views/OpenshiftView.java
@@ -78,7 +78,7 @@ public class OpenshiftView extends ContainerFixture {
     public void menuRightClickAndSelect(RemoteRobot robot, int row, String selection) {
         getOpenshiftConnectorTree().clickRow(row);
         getOpenshiftConnectorTree().rightClickRow(row);
-        waitForComponentByXpath(robot, 5, 1, byXpath(getTextXPath(selection)));
+        waitForComponentByXpath(robot, 30, 5, byXpath(getTextXPath(selection)));
         find(ComponentFixture.class, byXpath(getTextXPath(selection))).click();
     }
 


### PR DESCRIPTION
Fixes #892. With my apologies I have noticed that the public tests have an instability to them, where every third or so would fail because of context menu or Login Dialog itself. I ran the test with this fix 20 or more times to verify and this fixes the instability.
![image](https://github.com/user-attachments/assets/e3e8072a-8bab-4b13-a682-5773e85ded26)
