### PR TITLE
fix: hookup 'install' button to return-key once button was created (#927)

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/openshift/ui/helm/install/InstallPanel.java
+++ b/src/main/java/org/jboss/tools/intellij/openshift/ui/helm/install/InstallPanel.java
@@ -141,12 +141,12 @@ public class InstallPanel extends JBPanel<InstallPanel> implements ChartPanel {
       .withValidator(new ReleaseNameValidator(releaseNameText))
       .installOn(releaseNameText)
       .andRegisterOnDocumentListener(releaseNameText);
-    releaseNameText.addKeyListener(onKeyPressed(installButton));
     add(releaseNameText, "spanx 2, pushx, growx");
 
     this.installButton = new JButton("Install");
     installButton.addActionListener(this::onInstall);
     add(installButton, "pushx, alignx right, aligny center, wrap");
+    releaseNameText.addKeyListener(onKeyPressed(installButton));
 
     add(new JBLabel("Active " + (odo.isOpenShift() ? "project:" : "namespace:")), "skip, pushx");
     this.currentProjectLabel = new JBLabel();


### PR DESCRIPTION
fixes #927