### PR TITLE
feat: allow hotswap in 'runIde' for >=IC-2024.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,7 +121,16 @@ tasks {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
+    fun supportsEnhancedClassRedefinition(): Boolean {
+        val platformVersion = findProperty("platformVersion").toString().toFloatOrNull()
+        return platformVersion != null
+                && platformVersion >= 2024.1
+    }
+
     runIde {
+        if (supportsEnhancedClassRedefinition()) {
+            jvmArgs("-XX:+AllowEnhancedClassRedefinition", "-XX:HotswapAgent=fatjar")
+        }
         systemProperty("com.redhat.devtools.intellij.telemetry.mode", "debug")
         findProperty("tools.dl.path")?.let { systemProperty("tools.dl.path", it) }
         //systemProperty("jboss.sandbox.api.endpoint", "http://localhost:3000") // enable when running sandbox locally, see below


### PR DESCRIPTION
This allows hot code swap when developing.

# Without the change:
**Steps:**
1. EXEC: add a line (ex. `System.err.println("hello")` in `RefreshAction#doActionPerformed`
```java
    public void doActionPerformed(ApplicationsRootNode root) {
System.err.println("hello");
        if (root == null) {
          return;
        }
```
2. ASSERT: In the editor, you are informed that you can hot-swap the code
<img src=https://github.com/user-attachments/assets/216a545c-4066-4e4f-be11-f760a4d90333 width=400/>

3. EXEC: click the bug icon to the right of the notification

**Result:**
Hot swap fails
<img src=https://github.com/user-attachments/assets/87834bb9-e7bb-4736-8805-0a27b79aa308 width=400/>

# With the change:
**Steps:**
1. EXEC: change the line that you added above`RefreshAction#doActionPerformed`
2. ASSERT: In the editor, you are informed that you can hot-swap the code
<img src=https://github.com/user-attachments/assets/216a545c-4066-4e4f-be11-f760a4d90333 width)=400/>
1. EXEC: click the bug icon to the right of the notification

**Result:**
Hot swap succeeds
<img src=https://github.com/user-attachments/assets/48d21ab9-2f76-4c9b-9bb4-19781d0d88bb width=400/>
