### PR TITLE
fix: bump kubernetes-client to 7.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
-openshift-client = "7.0.0"
+openshift-client = "7.1.0"
 devtools-common = "1.9.7"
 keycloak = "24.0.5"
 jsonwebtoken = "0.12.6"


### PR DESCRIPTION
bumps the kubernetes client to the latest stable version currently, 7.1.0